### PR TITLE
fix: didn't publish types to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "not dead"
   ],
   "files": [
-    "dist"
+    "dist",
+    "types"
   ],
   "dependencies": {
     "rematrix": "^0.7.2"


### PR DESCRIPTION
This is the following up fix for #80 that I forgot to add `types` folder into `files` field in `package.json`, so that the typing files were even not published to npm at all. Sorry about that!