### PR TITLE
fix: declaration should prefix with `declare`

### DIFF
--- a/types/flipbook.d.ts
+++ b/types/flipbook.d.ts
@@ -15,7 +15,7 @@ export interface SlotScope {
   zoomIn(): void
   zoomOut(): void
 }
-const component: Vue.DefineComponent<
+declare const component: Vue.DefineComponent<
   {
     pages: string[]
     pagesHiRes?: string[]


### PR DESCRIPTION
...in dts files

Otherwise:
```
Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.ts(1046)
```